### PR TITLE
Instead of using a lambda, use a block

### DIFF
--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -24,11 +24,14 @@ pub (crate) fn gen_pattern(mut pattern : Pattern) -> Rc<str> {
 
     let guards = (0..total_ids).map(|x| format!("let mut x_{x} = true;")).collect::<Vec<_>>().join("");
 
-    // TODO input : &_ ?
     let w :Rc<str>= 
         format!(
             
-            "|input| {{
+            "{{
+
+            use std::borrow::Borrow;
+
+            let input = x.borrow();
             
             {guards}
 

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -17,6 +17,8 @@ pub (crate) fn gen_pattern(mut pattern : Pattern) -> Rc<str> {
         }
     }
 
+    let target = pattern.target;
+
     // Note:  Compute this first so that ID will have the correct value.
     let match_statement = r_to_str(&ret);
 
@@ -31,7 +33,7 @@ pub (crate) fn gen_pattern(mut pattern : Pattern) -> Rc<str> {
 
             use std::borrow::Borrow;
 
-            let input = x.borrow();
+            let input = {target}.borrow();
             
             {guards}
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -7,6 +7,7 @@ pub (crate) struct Clause {
 }
 
 pub (crate) struct Pattern {
+    pub (crate) target : Rc<str>,
     pub (crate) clauses : Vec<Clause>,
     pub (crate) return_expr : Rc<str>,
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -20,6 +20,11 @@ macro_rules! proj {
 }
 
 pub (crate) fn parse(input : &mut Parser<TokenTree>) -> Result<Pattern, ()> {
+
+    let target : Rc<str> = proj!(input, x @ TokenTree::Ident(_), x.to_string().into())?;
+    proj!(input, TokenTree::Punct(p) if p.as_char() == '=', ())?;
+    proj!(input, TokenTree::Punct(p) if p.as_char() == '>', ())?;
+
     let clauses = {
         let first_pattern = pattern(input)?;
 
@@ -40,7 +45,7 @@ pub (crate) fn parse(input : &mut Parser<TokenTree>) -> Result<Pattern, ()> {
 
     let return_expr : Rc<str> = input.list(|input| Ok(input.get(())?.to_string()))?.join("").into();   // TODO get error
 
-    Ok(Pattern { clauses, return_expr })
+    Ok(Pattern { target, clauses, return_expr })
 }
 
 fn pattern(input : &mut Parser<TokenTree>) -> Result<Rc<str>, ()> {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -21,8 +21,9 @@ fn should() {
 fn should_2() {
     #[derive(Debug, PartialEq)]
     struct W(usize);
+
     let x = (((W(1), W(2)), (W(3), W(4))), ((W(5), W(6)), (W(7), W(8))));
-    let m = blarg!([ (y, z) ] y, z ; [(w, h)] w, h; [(l, r)]  => (l, r));
+    let m = blarg!(x => [ (y, z) ] y, z ; [(w, h)] w, h; [(l, r)]  => (l, r));
 
     let a = m.take(100).collect::<Vec<_>>();
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -19,11 +19,12 @@ fn should() {
 
 #[test]
 fn should_2() {
-    let x = (((1, 2), (3, 4)), ((5, 6), (7, 8)));
+    #[derive(Debug, PartialEq)]
+    struct W(usize);
+    let x = (((W(1), W(2)), (W(3), W(4))), ((W(5), W(6)), (W(7), W(8))));
     let m = blarg!([ (y, z) ] y, z ; [(w, h)] w, h; [(l, r)]  => (l, r));
-    let o = m(x);
 
-    let a = o.take(100).collect::<Vec<_>>();
+    let a = m.take(100).collect::<Vec<_>>();
 
     assert_eq!(a, vec![]);
 }


### PR DESCRIPTION
The lambda eating input was causing problems with the borrow checker and lifetimes.

Just having a block seems to fix everything.  Although the downside is that now a target identifier has to be provided to the macro inputs.

This is the same thing that intra ended up doing.